### PR TITLE
Include compiler flag for math library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Linux
 CC = gcc
 DEPS = `pkg-config --cflags SDL2_image SDL2_mixer SDL2_ttf glib-2.0 lua`
-DEPS_LIBS = `pkg-config --libs SDL2_image SDL2_mixer SDL2_ttf glib-2.0 lua`
+DEPS_LIBS = `pkg-config --libs SDL2_image SDL2_mixer SDL2_ttf glib-2.0 lua` -lm
 OPTS = -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wunused #-Werror #-O2
 GDB = -g -ggdb
 #~ ASAN = -O1 -g3 -ggdb3 -fno-omit-frame-pointer -fsanitize=address -fno-sanitize-recover=all -fsanitize-address-use-after-scope


### PR DESCRIPTION
While it seems that on some systems this is done implicitly, on others it results in an error.

Specifically, I'm on 22.04.1 with gcc (Ubuntu 11.3.0-1ubuntu1~22.04). Since you're using Fedora, this is possibly included there by default.