### PR TITLE
Ubuntu-specific dependency notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ To compile KIAVC, you'll need the following dependencies (development versions):
 * [GLib](https://docs.gtk.org/glib/)
 * [Lua](https://www.lua.org/download.html)
 
+### Installing dependencies on Ubuntu
+
+```
+sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libglib2.0-dev liblua5.4-dev
+```
+
+It's possible only the newest Lua dev library (currently 5.4) will be found at compilation.
+
 ## Compiling KIAVC
 
 Once you have installed all the dependencies, get the code:


### PR DESCRIPTION
This is not a fix, more of a question: It' possible you don't want to include specific package names in the ReadMe (or also do it for at least Fedora), but it's possibly helpful, at least because I found that GCC only finds the Lua dev library if 5.4 is installed, not for 5.1-5.3 which are also currently available in Ubuntu repos. (5.3 is the one currently marked as the main one for the distro.)

If you don't want to put this in the ReadMe (which I also completely understand, I'm not even completely sure it belongs here) you may consider enabling the Wiki to put a note there in case someone gets tripped up by this, or just needs help finding packages.