### PR TITLE
Simplify engine version requirement method

### DIFF
--- a/demo/lua/main.lua
+++ b/demo/lua/main.lua
@@ -1,5 +1,8 @@
 -- We may want to make sure we're using a specific version of the engine
-requireVersion(0, 1, 0)
+requireEngineVersion(0, 1, 0)
+-- Or we may just require the same major version with a minimum minor and patch
+requireEngineCompatible(0, 1, 0)
+
 
 -- Let's load all the resources first
 kiavcRequire('game/resources')

--- a/demo/lua/main.lua
+++ b/demo/lua/main.lua
@@ -1,9 +1,5 @@
 -- We may want to make sure we're using a specific version of the engine
-major, minor, patch = getVersion()
-if major ~= 0 or minor ~= 1 or patch ~= 0 then
-	kiavcLog('Unsupported KIAVC engine version')
-	return
-end
+requireVersion(0, 1, 0)
 
 -- Let's load all the resources first
 kiavcRequire('game/resources')

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -34,8 +34,10 @@ static int kiavc_lua_method_kiavcrequire(lua_State *s);
 static int kiavc_lua_method_getversion(lua_State *s);
 /* Return version string */
 static int kiavc_lua_method_getversionstring(lua_State *s);
-/* Require version as major, minor, patch */
-static int kiavc_lua_method_requireversion(lua_State *s);
+/* Require compatibility of version as major, minor, patch */
+static int kiavc_lua_method_requireenginecompatible(lua_State *s);
+/* Require exact version as major, minor, patch */
+static int kiavc_lua_method_requireengineversion(lua_State *s);
 /* Logging, to use the same SDL-based logging as the rest of the application */
 static int kiavc_lua_method_kiavclog(lua_State *s);
 /* Error logging, to use the same SDL-based logging as the rest of the application */
@@ -315,7 +317,8 @@ int kiavc_scripts_load(const char *path, const kiavc_scripts_callbacks *callback
 	lua_register(lua_state, "kiavcRequire", kiavc_lua_method_kiavcrequire);
 	lua_register(lua_state, "getVersion", kiavc_lua_method_getversion);
 	lua_register(lua_state, "getVersionString", kiavc_lua_method_getversionstring);
-	lua_register(lua_state, "requireVersion", kiavc_lua_method_requireversion);
+	lua_register(lua_state, "requireEngineCompatible", kiavc_lua_method_requireenginecompatible);
+	lua_register(lua_state, "requireEngineVersion", kiavc_lua_method_requireengineversion);
 	lua_register(lua_state, "kiavcLog", kiavc_lua_method_kiavclog);
 	lua_register(lua_state, "kiavcError", kiavc_lua_method_kiavcerror);
 	lua_register(lua_state, "kiavcWarn", kiavc_lua_method_kiavcwarn);
@@ -559,12 +562,12 @@ static int kiavc_lua_method_getversionstring(lua_State *s) {
 	return 1;
 }
 
-/* Require version as major, minor, patch */
-static int kiavc_lua_method_requireversion(lua_State *s) {
-	/* This method allows the Lua script to check whether the engine is of a compatible version (and quit if not) */
+/* Require compatibility of version as major, minor, patch */
+static int kiavc_lua_method_requireenginecompatible(lua_State *s) {
+	/* This method is the common core of the two engine version checker functions */
 	int n = lua_gettop(s), exp = 3;
 	if(n != exp) {
-		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] Wrong number of arguments in requireVersion: %d (expected %d)\n", n, exp);
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] Wrong number of arguments (require engine compatible): %d (expected %d)\n", n, exp);
 		kiavc_cb->quit();
 		return 0;
 	}
@@ -585,6 +588,37 @@ static int kiavc_lua_method_requireversion(lua_State *s) {
 		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number too low: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
 		kiavc_cb->quit();
 		return 0;
+	}
+	return 0;
+}
+
+/* Require exact version as major, minor, patch */
+static int kiavc_lua_method_requireengineversion(lua_State *s) {
+	/* This method is the common core of the two engine version checker functions */
+	int n = lua_gettop(s), exp = 3;
+	if(n != exp) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] Wrong number of arguments (require engine version): %d (expected %d)\n", n, exp);
+		kiavc_cb->quit();
+		return 0;
+	}
+	short differences = 0;
+	int major = luaL_checknumber(s, 1);
+	if(major != KIAVC_VERSION_MAJOR) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC major version number mismatch: %d (expected %d)\n", KIAVC_VERSION_MAJOR, major);
+		differences += 1;
+	}
+	int minor = luaL_checknumber(s, 2);
+	if(minor > KIAVC_VERSION_MINOR) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC minor version number mismatch: %d (expected %d)\n", KIAVC_VERSION_MINOR, minor);
+		differences += 1;
+	}
+	int patch = luaL_checknumber(s, 3);
+	if(patch > KIAVC_VERSION_PATCH) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number mismatch: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
+		differences += 1;
+	}
+	if (differences > 0) {
+		kiavc_cb->quit();
 	}
 	return 0;
 }

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -34,6 +34,8 @@ static int kiavc_lua_method_kiavcrequire(lua_State *s);
 static int kiavc_lua_method_getversion(lua_State *s);
 /* Return version string */
 static int kiavc_lua_method_getversionstring(lua_State *s);
+/* Require version as major, minor, patch */
+static int kiavc_lua_method_requireversion(lua_State *s);
 /* Logging, to use the same SDL-based logging as the rest of the application */
 static int kiavc_lua_method_kiavclog(lua_State *s);
 /* Error logging, to use the same SDL-based logging as the rest of the application */
@@ -313,6 +315,7 @@ int kiavc_scripts_load(const char *path, const kiavc_scripts_callbacks *callback
 	lua_register(lua_state, "kiavcRequire", kiavc_lua_method_kiavcrequire);
 	lua_register(lua_state, "getVersion", kiavc_lua_method_getversion);
 	lua_register(lua_state, "getVersionString", kiavc_lua_method_getversionstring);
+	lua_register(lua_state, "requireVersion", kiavc_lua_method_requireversion);
 	lua_register(lua_state, "kiavcLog", kiavc_lua_method_kiavclog);
 	lua_register(lua_state, "kiavcError", kiavc_lua_method_kiavcerror);
 	lua_register(lua_state, "kiavcWarn", kiavc_lua_method_kiavcwarn);
@@ -554,6 +557,36 @@ static int kiavc_lua_method_getversionstring(lua_State *s) {
 	}
 	lua_pushstring(s, KIAVC_VERSION_STRING);
 	return 1;
+}
+
+/* Require version as major, minor, patch */
+static int kiavc_lua_method_requireversion(lua_State *s) {
+	/* This method allows the Lua script to check whether the engine is of a compatible version (and quit if not) */
+	int n = lua_gettop(s), exp = 3;
+	if(n != exp) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] Wrong number of arguments in requireVersion: %d (expected %d)\n", n, exp);
+		kiavc_cb->quit();
+		return 0;
+	}
+	int major = luaL_checknumber(s, 1);
+	if(major != KIAVC_VERSION_MAJOR) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC major version number incompatible: %d (expected %d)\n", KIAVC_VERSION_MAJOR, major);
+        kiavc_cb->quit();
+        return 0;
+    }
+	int minor = luaL_checknumber(s, 2);
+	if(minor > KIAVC_VERSION_MINOR) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC minor version number too low: %d (expected %d)\n", KIAVC_VERSION_MINOR, minor);
+        kiavc_cb->quit();
+        return 0;
+    }
+	int patch = luaL_checknumber(s, 3);
+	if(patch > KIAVC_VERSION_PATCH) {
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number too low: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
+        kiavc_cb->quit();
+        return 0;
+    }
+	return 0;
 }
 
 /* Logging, to use the same SDL-based logging as the rest of the application */

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -570,22 +570,22 @@ static int kiavc_lua_method_requireversion(lua_State *s) {
 	}
 	int major = luaL_checknumber(s, 1);
 	if(major != KIAVC_VERSION_MAJOR) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC major version number incompatible: %d (expected %d)\n", KIAVC_VERSION_MAJOR, major);
-        kiavc_cb->quit();
-        return 0;
-    }
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC major version number incompatible: %d (expected %d)\n", KIAVC_VERSION_MAJOR, major);
+		kiavc_cb->quit();
+		return 0;
+	}
 	int minor = luaL_checknumber(s, 2);
 	if(minor > KIAVC_VERSION_MINOR) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC minor version number too low: %d (expected %d)\n", KIAVC_VERSION_MINOR, minor);
-        kiavc_cb->quit();
-        return 0;
-    }
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC minor version number too low: %d (expected %d)\n", KIAVC_VERSION_MINOR, minor);
+		kiavc_cb->quit();
+		return 0;
+	}
 	int patch = luaL_checknumber(s, 3);
 	if(patch > KIAVC_VERSION_PATCH) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number too low: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
-        kiavc_cb->quit();
-        return 0;
-    }
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number too low: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
+		kiavc_cb->quit();
+		return 0;
+	}
 	return 0;
 }
 

--- a/src/scripts.c
+++ b/src/scripts.c
@@ -584,7 +584,7 @@ static int kiavc_lua_method_requireenginecompatible(lua_State *s) {
 		return 0;
 	}
 	int patch = luaL_checknumber(s, 3);
-	if(patch > KIAVC_VERSION_PATCH) {
+	if(minor == KIAVC_VERSION_MINOR && patch > KIAVC_VERSION_PATCH) {
 		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "[Lua] KIAVC patch version number too low: %d (expected %d)\n", KIAVC_VERSION_PATCH, patch);
 		kiavc_cb->quit();
 		return 0;


### PR DESCRIPTION
This change moves the checking of the engine version into the engine code, simplifying the method call needed in the game Lua file.

Behavior is slightly different: major version quits on any difference, minor and patch only quit if the required version is larger than the available one. This is consistent with SemVer, but a matter of decision.

The code itself definitely needs to be checked. I believe I added the change in all required places and tested it running on my machine, I'm not yet familiar enough with the codebase.

A possible issue is that the error log entry is displayed after script loading, but the init INFO entries are all still displayed before the game exits, obfuscating the source of the error further up in the log. On the other hand, the current version fails with an INFO on "Unsupported KIAVC engine version", then two CRITICAL-s: screen resolution and engine init. While this is obviously shorter and clearer, the screen resolution line could still be misleading.

It's also possible, that the previously used getVersion method could be removed. For display purposes there is getVersionString, but if requirement checking is not in the scripts, getting the numbers separately may not be necessary.