### PR TITLE
Copy docstring from source to header file

### DIFF
--- a/src/actor.h
+++ b/src/actor.h
@@ -4,7 +4,8 @@
  * mostly takes into account what the C side of the engine needs to
  * know, since all the logic related to the actual actor properties and
  * actions will sit in the Lua script instead. As such, we only keep
- * track of the costume it's "wearing", plus additional information
+ * track of the images and animations we may need to render (e.g., when
+ * standing still, walking or talking), plus additional information
  * related to rendering, like the direction the actor is facing, their
  * coordinates in a room, where they're going, etc.
  *


### PR DESCRIPTION
The file-level docstrings are the same for source and header files, except for actor. This change corrects that, using the version that seemed more complete.

It might be worth considering removing the duplication in some way. E.g. leaving it in the sources (and the few headers without attached .c files) and having only references ti these in the headers.