### PR TITLE
Simplify object interactions in Lua

### DIFF
--- a/demo/lua/game/objects/envelope.lua
+++ b/demo/lua/game/objects/envelope.lua
@@ -28,39 +28,37 @@ local envelope = Object:new({
 				waitFor(activeActor.id)
 			end
 			rooms['letter']:enter()
-		end,
-		useWith = function(self, object)
-			if self.owner == nil then
-				activeActor:say(text('envelopeUse'))
-				return
-			end
-			if object == "fire" then
-				activeActor:say(text('envelopeUseFire'))
-			elseif object == "skyline" then
-				activeActor:say(text('envelopeUseSkyline'))
-			elseif object == "restaurant" then
-				activeActor:look("down")
-				activeActor:say(text('envelopeUseRestaurant'))
-			elseif object == "girls" then
-				activeActor:look("down")
-				activeActor:say(text('envelopeUseGirls'))
-			elseif object == "boat" then
-				activeActor:look("down")
-				activeActor:say(text('envelopeUseBoat'))
-			elseif object == "skull" then
-				activeActor:look("down")
-				activeActor:say(text('envelopeUseSkull'))
-			elseif object == "props" then
-				activeActor:say(text('defaultUseWith'))
-			end
 		end
+	},
+	objectInteractionNotOwned = function()
+        activeActor:say(text('envelopeUse'))
+    end,
+	objectInteractions = {
+	    fire = function()
+            activeActor:say(text('envelopeUseFire'))
+        end,
+        skyline = function()
+            activeActor:say(text('envelopeUseSkyline'))
+        end,
+        restaurant = function()
+            activeActor:look("down")
+            activeActor:say(text('envelopeUseRestaurant'))
+        end,
+        girls = function()
+            activeActor:look("down")
+            activeActor:say(text('envelopeUseGirls'))
+        end,
+        boat = function()
+            activeActor:look("down")
+            activeActor:say(text('envelopeUseBoat'))
+        end,
+        skull = function()
+            activeActor:look("down")
+            activeActor:say(text('envelopeUseSkull'))
+        end
 	},
 	onRightClick = 'lookAt',
 	onLeftClick = 'select'
 })
-
--- Let's define the map of possible object interactions for this object
-objectInteractions.envelope =
-	{ skyline = true, restaurant = true, girls = true, fire = true, boat = true, skull = true, props = true }
 
 -- By default, we put the envelope in the inventory, which we'll do later

--- a/demo/lua/game/objects/envelope.lua
+++ b/demo/lua/game/objects/envelope.lua
@@ -31,31 +31,31 @@ local envelope = Object:new({
 		end
 	},
 	objectInteractionNotOwned = function()
-        activeActor:say(text('envelopeUse'))
-    end,
+		activeActor:say(text('envelopeUse'))
+	end,
 	objectInteractions = {
-	    fire = function()
-            activeActor:say(text('envelopeUseFire'))
-        end,
-        skyline = function()
-            activeActor:say(text('envelopeUseSkyline'))
-        end,
-        restaurant = function()
-            activeActor:look("down")
-            activeActor:say(text('envelopeUseRestaurant'))
-        end,
-        girls = function()
-            activeActor:look("down")
-            activeActor:say(text('envelopeUseGirls'))
-        end,
-        boat = function()
-            activeActor:look("down")
-            activeActor:say(text('envelopeUseBoat'))
-        end,
-        skull = function()
-            activeActor:look("down")
-            activeActor:say(text('envelopeUseSkull'))
-        end
+		fire = function()
+			activeActor:say(text('envelopeUseFire'))
+		end,
+		skyline = function()
+			activeActor:say(text('envelopeUseSkyline'))
+		end,
+		restaurant = function()
+			activeActor:look("down")
+			activeActor:say(text('envelopeUseRestaurant'))
+		end,
+		girls = function()
+			activeActor:look("down")
+			activeActor:say(text('envelopeUseGirls'))
+		end,
+		boat = function()
+			activeActor:look("down")
+			activeActor:say(text('envelopeUseBoat'))
+		end,
+		skull = function()
+			activeActor:look("down")
+			activeActor:say(text('envelopeUseSkull'))
+		end
 	},
 	onRightClick = 'lookAt',
 	onLeftClick = 'select'

--- a/demo/lua/game/objects/skull.lua
+++ b/demo/lua/game/objects/skull.lua
@@ -48,37 +48,34 @@ local skull = Object:new({
 			waitMs(500)
 			self:addToInventory(activeActor.id)
 			activeActor:setState('still')
-		end,
-		useWith = function(self, object)
-			if self.owner == nil then
-				activeActor:say(text('skullUse'))
-				return
-			end
-			if object == "fire" then
-				activeActor:say(text('skullUseFire'))
-			elseif object == "skyline" then
-				activeActor:say(text('skullUseSkyline'))
-			elseif object == "restaurant" then
-				activeActor:look("down")
-				activeActor:say(text('skullUseRestaurant'))
-			elseif object == "girls" then
-				activeActor:look("down")
-				activeActor:say(text('skullUseGirls'))
-			elseif object == "boat" then
-				activeActor:look("down")
-				activeActor:say(text('skullUseBoat'))
-			elseif object == "props" then
-				activeActor:say(text('defaultUseWith'))
-			end
 		end
 	},
+	objectInteractionNotOwned = function()
+        activeActor:say(text('skullUse'))
+    end,
+    objectInteractions = {
+        fire = function()
+            activeActor:say(text('skullUseFire'))
+        end,
+        skyline = function()
+            activeActor:say(text('skullUseSkyline'))
+        end,
+        restaurant = function()
+            activeActor:look("down")
+            activeActor:say(text('skullUseRestaurant'))
+        end,
+        girls = function()
+            activeActor:look("down")
+            activeActor:say(text('skullUseGirls'))
+        end,
+        boat = function()
+            activeActor:look("down")
+            activeActor:say(text('skullUseBoat'))
+        end
+    },
 	onRightClick = 'lookAt',
 	onLeftClick = 'pickUp'
 })
-
--- Let's define the map of possible object interactions for this object
-objectInteractions.skull =
-	{ skyline = true, restaurant = true, girls = true, fire = true, boat = true, props = true }
 
 -- By default, we put the skull in the Melee harbour room
 skull:moveTo('outskirts', 178, 166)

--- a/demo/lua/game/objects/skull.lua
+++ b/demo/lua/game/objects/skull.lua
@@ -51,28 +51,28 @@ local skull = Object:new({
 		end
 	},
 	objectInteractionNotOwned = function()
-        activeActor:say(text('skullUse'))
-    end,
-    objectInteractions = {
-        fire = function()
-            activeActor:say(text('skullUseFire'))
-        end,
-        skyline = function()
-            activeActor:say(text('skullUseSkyline'))
-        end,
-        restaurant = function()
-            activeActor:look("down")
-            activeActor:say(text('skullUseRestaurant'))
-        end,
-        girls = function()
-            activeActor:look("down")
-            activeActor:say(text('skullUseGirls'))
-        end,
-        boat = function()
-            activeActor:look("down")
-            activeActor:say(text('skullUseBoat'))
-        end
-    },
+		activeActor:say(text('skullUse'))
+	end,
+	objectInteractions = {
+		fire = function()
+			activeActor:say(text('skullUseFire'))
+		end,
+		skyline = function()
+			activeActor:say(text('skullUseSkyline'))
+		end,
+		restaurant = function()
+			activeActor:look("down")
+			activeActor:say(text('skullUseRestaurant'))
+		end,
+		girls = function()
+			activeActor:look("down")
+			activeActor:say(text('skullUseGirls'))
+		end,
+		boat = function()
+			activeActor:look("down")
+			activeActor:say(text('skullUseBoat'))
+		end
+	},
 	onRightClick = 'lookAt',
 	onLeftClick = 'pickUp'
 })

--- a/lua/engine/object.lua
+++ b/lua/engine/object.lua
@@ -1,6 +1,5 @@
 -- Global properties
 objects = {}
-objectInteractions = {}
 selectedObject = nil
 
 -- Objects class
@@ -8,6 +7,10 @@ Object = {
 	inventory = false,
 	ui = false,
 	interactable = true,
+	objectInteractions = {},
+	objectInteractionNotOwned = function()
+	    return
+    end,
 	onAction = 'useWith',
 	defaultVerbs = {
 		lookAt = function(self)
@@ -64,23 +67,25 @@ Object = {
 				activeActor:say(text('defaultUse'))
 			end
 		end,
-		useWith = function(self, object)
-			if object == nil or objects[object] == nil then
+		useWith = function(self, objectId)
+			if objectId == nil or objects[objectId] == nil then
 				return
 			end
-			kiavcLog('Trying to use ' .. self.id .. ' with ' .. object)
-			if self.id == object then
+			kiavcLog("Trying to use '" .. self.id .. "' with '" .. objectId .. "'")
+			if self.id == objectId then
 				return
 			end
-			if objectInteractions[object] and objectInteractions[object][self.id] == true then
-				local obj = objects[object]
-				obj.verbs.useWith(obj, self.id)
-				return
-			end
-			if translations == nil then
-				activeActor:say("I can't use them together.")
+			local obj = objects[objectId]
+			if obj.owner == nil then
+                obj.objectInteractionNotOwned()
+			elseif obj.objectInteractions[self.id] ~= nil then
+				obj.objectInteractions[self.id]()
 			else
-				activeActor:say(text('defaultUseWith'))
+                if translations == nil then
+                    activeActor:say("I can't use them together.")
+                else
+                    activeActor:say(text('defaultUseWith'))
+                end
 			end
 		end,
 		giveTo = function(self, object)
@@ -369,12 +374,7 @@ Object = {
 				waitMs(200)
 			end
 			if selectedObject ~= nil and self.onAction ~= nil and self.verbs[self.onAction] ~= nil then
-				if self.onAction == 'useWith' and objectInteractions[selectedObject] and objectInteractions[selectedObject][self.id] == true then
-					local obj = objects[selectedObject]
-					obj.verbs.useWith(obj, self.id)
-				else
-					self.verbs[self.onAction](self, selectedObject)
-				end
+				self.verbs[self.onAction](self, selectedObject)
 			elseif self.onLeftClick ~= nil and self.verbs[self.onLeftClick] ~= nil then
 				self.verbs[self.onLeftClick](self, selectedObject)
 			end

--- a/lua/engine/object.lua
+++ b/lua/engine/object.lua
@@ -9,8 +9,8 @@ Object = {
 	interactable = true,
 	objectInteractions = {},
 	objectInteractionNotOwned = function()
-	    return
-    end,
+		return
+	end,
 	onAction = 'useWith',
 	defaultVerbs = {
 		lookAt = function(self)
@@ -77,15 +77,15 @@ Object = {
 			end
 			local obj = objects[objectId]
 			if obj.owner == nil then
-                obj.objectInteractionNotOwned()
+				obj.objectInteractionNotOwned()
 			elseif obj.objectInteractions[self.id] ~= nil then
 				obj.objectInteractions[self.id]()
 			else
-                if translations == nil then
-                    activeActor:say("I can't use them together.")
-                else
-                    activeActor:say(text('defaultUseWith'))
-                end
+				if translations == nil then
+					activeActor:say("I can't use them together.")
+				else
+					activeActor:say(text('defaultUseWith'))
+				end
 			end
 		end,
 		giveTo = function(self, object)


### PR DESCRIPTION
This change is meant to reduce the code required for object interactions, and doing the default only in the verb function.

One thing I'm not clear on is when the `self.owner == nil` part (now also moved) would occur. I wasn't able to test whether that part works correctly, because I wasn't able to produce that effect before the change, either.